### PR TITLE
feat: refresh token 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,9 @@ dependencies {
     // Spring Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.security:spring-security-test'
+
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/example/expert/config/JwtUtil.java
+++ b/src/main/java/org/example/expert/config/JwtUtil.java
@@ -100,4 +100,10 @@ public class JwtUtil {
                 .userRole(UserRole.of(claims.get("role", String.class)))
                 .build();
     }
+
+    public Long getUserIdFromToken(String token) {
+        Claims claims = extractClaims(token);
+
+        return Long.valueOf(claims.get("id", String.class));
+    }
 }

--- a/src/main/java/org/example/expert/config/JwtUtil.java
+++ b/src/main/java/org/example/expert/config/JwtUtil.java
@@ -32,7 +32,7 @@ public class JwtUtil {
         key = Keys.hmacShaKeyFor(bytes);
     }
 
-    public String generateToken(Long id, String email, String nickname, UserRole role) {
+    public String generateAccessToken(Long id, String email, String nickname, UserRole role) {
         Date now = new Date();
 
         return BEARER_PREFIX + Jwts.builder()

--- a/src/main/java/org/example/expert/config/RedisConfig.java
+++ b/src/main/java/org/example/expert/config/RedisConfig.java
@@ -1,6 +1,5 @@
 package org.example.expert.config;
 
-import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/org/example/expert/config/RedisConfig.java
+++ b/src/main/java/org/example/expert/config/RedisConfig.java
@@ -1,0 +1,27 @@
+package org.example.expert.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+}

--- a/src/main/java/org/example/expert/config/SecurityConfig.java
+++ b/src/main/java/org/example/expert/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package org.example.expert.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import org.example.expert.domain.auth.repository.RedisRefreshTokenRepository;
 import org.example.expert.security.filter.CustomAuthenticationFilter;
 import org.example.expert.security.handler.SecurityAccessDeniedHandler;
 import org.example.expert.security.handler.SecurityAuthenticationEntryPoint;
@@ -30,6 +31,7 @@ public class SecurityConfig {
     private final JwtUtil jwtUtil;
     private final ObjectMapper objectMapper;
     private final AuthenticationConfiguration authenticationConfiguration;
+    private final RedisRefreshTokenRepository refreshTokenRepository;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -69,7 +71,7 @@ public class SecurityConfig {
     public CustomAuthenticationFilter customAuthenticationFilter() throws Exception {
         CustomAuthenticationFilter filter = new CustomAuthenticationFilter(objectMapper);
         filter.setAuthenticationManager(authenticationManager());
-        filter.setAuthenticationSuccessHandler(new SecurityAuthenticationSuccessHandler(jwtUtil, objectMapper));
+        filter.setAuthenticationSuccessHandler(new SecurityAuthenticationSuccessHandler(jwtUtil, objectMapper, refreshTokenRepository));
         filter.setAuthenticationFailureHandler(new SecurityAuthenticationFailureHandler(objectMapper));
 
         filter.setSecurityContextRepository(

--- a/src/main/java/org/example/expert/domain/auth/controller/AuthController.java
+++ b/src/main/java/org/example/expert/domain/auth/controller/AuthController.java
@@ -2,11 +2,13 @@ package org.example.expert.domain.auth.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.example.expert.domain.auth.dto.request.AuthReissueRequest;
 import org.example.expert.domain.auth.dto.request.SigninRequest;
 import org.example.expert.domain.auth.dto.request.SignupRequest;
 import org.example.expert.domain.auth.dto.response.SigninResponse;
 import org.example.expert.domain.auth.dto.response.SignupResponse;
 import org.example.expert.domain.auth.service.AuthService;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -20,5 +22,12 @@ public class AuthController {
     @PostMapping("/auth/signup")
     public SignupResponse signup(@Valid @RequestBody SignupRequest signupRequest) {
         return authService.signup(signupRequest);
+    }
+
+    @PostMapping("/auth/reissue")
+    public void reissue(
+            @RequestBody AuthReissueRequest authReissueRequest
+    ) {
+        authService.reissueToken(authReissueRequest);
     }
 }

--- a/src/main/java/org/example/expert/domain/auth/controller/AuthController.java
+++ b/src/main/java/org/example/expert/domain/auth/controller/AuthController.java
@@ -5,9 +5,11 @@ import lombok.RequiredArgsConstructor;
 import org.example.expert.domain.auth.dto.request.AuthReissueRequest;
 import org.example.expert.domain.auth.dto.request.SigninRequest;
 import org.example.expert.domain.auth.dto.request.SignupRequest;
+import org.example.expert.domain.auth.dto.response.AuthReissueResponse;
 import org.example.expert.domain.auth.dto.response.SigninResponse;
 import org.example.expert.domain.auth.dto.response.SignupResponse;
 import org.example.expert.domain.auth.service.AuthService;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -25,9 +27,10 @@ public class AuthController {
     }
 
     @PostMapping("/auth/reissue")
-    public void reissue(
+    public ResponseEntity<AuthReissueResponse> reissue(
             @RequestBody AuthReissueRequest authReissueRequest
     ) {
-        authService.reissueToken(authReissueRequest);
+        return ResponseEntity.ok()
+                .body(authService.reissueToken(authReissueRequest));
     }
 }

--- a/src/main/java/org/example/expert/domain/auth/dto/request/AuthReissueRequest.java
+++ b/src/main/java/org/example/expert/domain/auth/dto/request/AuthReissueRequest.java
@@ -1,0 +1,11 @@
+package org.example.expert.domain.auth.dto.request;
+
+
+import jakarta.validation.constraints.NotBlank;
+
+public record AuthReissueRequest(
+
+        @NotBlank
+        String refreshToken
+) {
+}

--- a/src/main/java/org/example/expert/domain/auth/dto/response/AuthReissueResponse.java
+++ b/src/main/java/org/example/expert/domain/auth/dto/response/AuthReissueResponse.java
@@ -1,0 +1,7 @@
+package org.example.expert.domain.auth.dto.response;
+
+public record AuthReissueResponse(
+        String accessToken,
+        String refreshToken
+) {
+}

--- a/src/main/java/org/example/expert/domain/auth/dto/response/SigninResponse.java
+++ b/src/main/java/org/example/expert/domain/auth/dto/response/SigninResponse.java
@@ -5,9 +5,11 @@ import lombok.Getter;
 @Getter
 public class SigninResponse {
 
-    private final String bearerToken;
+    private final String accessToken;
+    private final String refreshToken;
 
-    public SigninResponse(String bearerToken) {
-        this.bearerToken = bearerToken;
+    public SigninResponse(String bearerToken, String refreshToken) {
+        this.accessToken = bearerToken;
+        this.refreshToken = refreshToken;
     }
 }

--- a/src/main/java/org/example/expert/domain/auth/dto/response/SignupResponse.java
+++ b/src/main/java/org/example/expert/domain/auth/dto/response/SignupResponse.java
@@ -5,9 +5,11 @@ import lombok.Getter;
 @Getter
 public class SignupResponse {
 
-    private final String bearerToken;
+    private final String accessToken;
+    private final String refreshToken;
 
-    public SignupResponse(String bearerToken) {
-        this.bearerToken = bearerToken;
+    public SignupResponse(String bearerToken, String refreshToken) {
+        this.accessToken = bearerToken;
+        this.refreshToken = refreshToken;
     }
 }

--- a/src/main/java/org/example/expert/domain/auth/entity/RedisRefreshToken.java
+++ b/src/main/java/org/example/expert/domain/auth/entity/RedisRefreshToken.java
@@ -8,7 +8,7 @@ import org.springframework.data.redis.core.RedisHash;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@RedisHash(value = "refresh_token")
+@RedisHash(value = "refresh_token", timeToLive = 12 * 60 * 60 * 1000L)
 public class RedisRefreshToken {
 
     @Id

--- a/src/main/java/org/example/expert/domain/auth/entity/RedisRefreshToken.java
+++ b/src/main/java/org/example/expert/domain/auth/entity/RedisRefreshToken.java
@@ -1,0 +1,23 @@
+package org.example.expert.domain.auth.entity;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@RedisHash(value = "refresh_token")
+public class RedisRefreshToken {
+
+    @Id
+    private Long userId;
+
+    private String refreshToken;
+
+    public RedisRefreshToken(Long userId, String refreshToken) {
+        this.userId = userId;
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/org/example/expert/domain/auth/repository/RedisRefreshTokenRepository.java
+++ b/src/main/java/org/example/expert/domain/auth/repository/RedisRefreshTokenRepository.java
@@ -1,0 +1,7 @@
+package org.example.expert.domain.auth.repository;
+
+import org.example.expert.domain.auth.entity.RedisRefreshToken;
+import org.springframework.data.repository.CrudRepository;
+
+public interface RedisRefreshTokenRepository extends CrudRepository<RedisRefreshToken, Long> {
+}

--- a/src/main/java/org/example/expert/domain/auth/service/AuthService.java
+++ b/src/main/java/org/example/expert/domain/auth/service/AuthService.java
@@ -40,8 +40,9 @@ public class AuthService {
         );
         User savedUser = userRepository.save(newUser);
 
-        String bearerToken = jwtUtil.generateToken(savedUser.getId(), savedUser.getEmail(), savedUser.getNickname(), savedUser.getUserRole());
-
-        return new SignupResponse(bearerToken);
+        return new SignupResponse(
+                jwtUtil.generateAccessToken(savedUser.getId(), savedUser.getEmail(), savedUser.getNickname(), savedUser.getUserRole()),
+                jwtUtil.generateRefreshToken(savedUser.getId())
+        );
     }
 }

--- a/src/main/java/org/example/expert/domain/auth/service/AuthService.java
+++ b/src/main/java/org/example/expert/domain/auth/service/AuthService.java
@@ -6,6 +6,9 @@ import org.example.expert.config.PasswordEncoder;
 import org.example.expert.domain.auth.dto.request.AuthReissueRequest;
 import org.example.expert.domain.auth.dto.request.SignupRequest;
 import org.example.expert.domain.auth.dto.response.SignupResponse;
+import org.example.expert.domain.auth.entity.RedisRefreshToken;
+import org.example.expert.domain.auth.exception.AuthException;
+import org.example.expert.domain.auth.repository.RedisRefreshTokenRepository;
 import org.example.expert.domain.common.exception.InvalidRequestException;
 import org.example.expert.domain.user.entity.User;
 import org.example.expert.domain.user.enums.UserRole;
@@ -18,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class AuthService {
 
+    private final RedisRefreshTokenRepository refreshTokenRepository;
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtUtil jwtUtil;

--- a/src/main/java/org/example/expert/domain/auth/service/AuthService.java
+++ b/src/main/java/org/example/expert/domain/auth/service/AuthService.java
@@ -3,6 +3,7 @@ package org.example.expert.domain.auth.service;
 import lombok.RequiredArgsConstructor;
 import org.example.expert.config.JwtUtil;
 import org.example.expert.config.PasswordEncoder;
+import org.example.expert.domain.auth.dto.request.AuthReissueRequest;
 import org.example.expert.domain.auth.dto.request.SignupRequest;
 import org.example.expert.domain.auth.dto.response.SignupResponse;
 import org.example.expert.domain.common.exception.InvalidRequestException;
@@ -44,5 +45,23 @@ public class AuthService {
                 jwtUtil.generateAccessToken(savedUser.getId(), savedUser.getEmail(), savedUser.getNickname(), savedUser.getUserRole()),
                 jwtUtil.generateRefreshToken(savedUser.getId())
         );
+    }
+
+    public void reissueToken(AuthReissueRequest authReissueRequest) {
+        // 요청 refresh token 검증
+        jwtUtil.isValid(authReissueRequest.refreshToken());
+
+        // 요청 refresh token에서 id 추출
+        Long userId = jwtUtil.getUserIdFromToken(authReissueRequest.refreshToken());
+
+        // redis에서 해당 id에 저장된 refresh token 조회
+
+        // refresh token 검증
+
+        // access token, refresh token 생성
+
+        // refresh token redis에 저장 (교체)
+
+        // access token, refresh token 반환
     }
 }

--- a/src/main/java/org/example/expert/domain/auth/service/AuthService.java
+++ b/src/main/java/org/example/expert/domain/auth/service/AuthService.java
@@ -41,9 +41,15 @@ public class AuthService {
         );
         User savedUser = userRepository.save(newUser);
 
+        String accessToken = jwtUtil.generateAccessToken(savedUser.getId(), savedUser.getEmail(), savedUser.getNickname(), savedUser.getUserRole());
+        String refreshToken = jwtUtil.generateRefreshToken(savedUser.getId());
+
+        RedisRefreshToken redisRefreshToken = new RedisRefreshToken(savedUser.getId(), refreshToken);
+        refreshTokenRepository.save(redisRefreshToken);
+
         return new SignupResponse(
-                jwtUtil.generateAccessToken(savedUser.getId(), savedUser.getEmail(), savedUser.getNickname(), savedUser.getUserRole()),
-                jwtUtil.generateRefreshToken(savedUser.getId())
+                accessToken,
+                refreshToken
         );
     }
 

--- a/src/main/java/org/example/expert/exception/error/ErrorCode.java
+++ b/src/main/java/org/example/expert/exception/error/ErrorCode.java
@@ -10,42 +10,7 @@ public enum ErrorCode {
 
     // 유저 관련 익셉션
     USER_EMAIL_NOT_FOUND(HttpStatus.CONFLICT, "해당 이메일로 가입된 유저가 없습니다."),
-    USER_EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 가입된 이메일입니다."),
-    INVALID_USER_ROLE(HttpStatus.BAD_REQUEST, "유효하지 않은 사용자 권한입니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "유저가 존재하지 않습니다."),
-    USER_DELETED(HttpStatus.GONE, "탈퇴한 유저입니다."),
-    UNAUTHORIZED_USER(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
-    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
-    DUPLICATED_PASSWORD(HttpStatus.CONFLICT, "이미 사용 중인 비밀번호입니다."),
-
-    // 메뉴, 주문 관련 익셉션
-    MENU_NOT_FOUND(HttpStatus.NOT_FOUND, "메뉴를 찾을 수 없습니다."),
-    MENU_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "이 메뉴는 이미 삭제되었습니다."),
-    ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "주문을 찾을 수 없습니다."),
-    ORDER_NOT_CHANGE(HttpStatus.NOT_FOUND, "주문 상태를 변경할 수 없습니다."),
-
-    // 가게 관련 익셉션
-    STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "가게가 존재하지 않습니다."),
-    STORE_ALREADY_DELETED(HttpStatus.CONFLICT, "이미 폐업 처리된 가게입니다."),
-    STORE_LIMIT_EXCEEDED(HttpStatus.CONFLICT, "가게는 최대 3개까지만 운영할 수 있습니다"),
-    INVALID_MIN_ORDER_PRICE_UNIT(HttpStatus.BAD_REQUEST, "최소 주문 금액은 천원 단위만 입력 가능합니다,"),
-
-    // 리뷰 관련 익셉션
-    INVALID_ORDER_STATUS(HttpStatus.BAD_REQUEST, "배달 완료 상태가 아닙니다."),
-    INVALID_STAR_RANGE(HttpStatus.BAD_REQUEST, "별점 범위가 유효하지 않습니다."),
-    STAR_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 별점의 리뷰가 없습니다."),
-    REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "리뷰가 존재하지 않습니다."),
-    DUPLICATE_REVIEW(HttpStatus.CONFLICT, "이미 리뷰가 작성된 주문입니다."),
-
-    // 즐겨찾기 관련 익셉션
-    DUPLICATED_FAVORITE(HttpStatus.CONFLICT, "이미 즐겨찾기한 가게입니다."),
-    FAVORITE_NOT_FOUND(HttpStatus.NOT_FOUND, "즐겨찾기가 존재하지 않습니다."),
-    SELF_FAVORITE_NOT_ALLOWED(HttpStatus.UNAUTHORIZED, "자기 자신의 가게를 즐겨찾기할 수 없습니다."),
-    SELF_ADD_REVIEW_NOT_ALLOWED(HttpStatus.UNAUTHORIZED, "자기 자신의 가게에 리뷰를 등록할 수 없습니다."),
-
-    // 댓글 관련 익셉션
-    DUPLICATED_REPLY(HttpStatus.CONFLICT, "이미 댓글이 작성된 리뷰입니다."),
-    REPLY_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글이 존재하지 않습니다."),
 
     // Security 관련 익셉션
     LOGIN_FAILED_EXCEPTION(HttpStatus.UNAUTHORIZED, "로그인에 실패하였습니다."),
@@ -53,12 +18,10 @@ public enum ErrorCode {
     AUTHORIZATION_EXCEPTION(HttpStatus.FORBIDDEN, "권한이 없습니다."),
 
     // JWT 관련 익셉션
-    JWT_TOKEN_ERROR(HttpStatus.BAD_REQUEST, "jwt token error"),
+    INVALID_TOKEN_ERROR(HttpStatus.BAD_REQUEST, "유효하지 않은 토큰입니다."),
 
-    // 장바구니 관련 익셉션
-    CART_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 유저의 장바구니가 존재하지 않습니다."),
-    CART_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "장바구니에 해당 메뉴가 존재하지 않습니다."),
-    INVALID_DECREASE_QUANTITY(HttpStatus.BAD_REQUEST, "수량이 0보다 적을 순 없습니다.");
+    REFRESH_TOKEN_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, "토큰이 존재하지 않습니다.")
+    ;
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/org/example/expert/security/handler/SecurityAuthenticationSuccessHandler.java
+++ b/src/main/java/org/example/expert/security/handler/SecurityAuthenticationSuccessHandler.java
@@ -24,8 +24,9 @@ public class SecurityAuthenticationSuccessHandler extends SimpleUrlAuthenticatio
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
         CustomUserDetails userCustom = (CustomUserDetails) authentication.getPrincipal();
-        String bearerToken = jwtUtil.generateAccessToken(userCustom.getId(), userCustom.getEmail(), userCustom.getUsername(), userCustom.getUserRole());
-        SigninResponse authLoginResponse = new SigninResponse(bearerToken);
+        String accessToken = jwtUtil.generateAccessToken(userCustom.getId(), userCustom.getEmail(), userCustom.getUsername(), userCustom.getUserRole());
+        String refreshToken = jwtUtil.generateRefreshToken(userCustom.getId());
+        SigninResponse authLoginResponse = new SigninResponse(accessToken, refreshToken);
 
         response.setContentType("application/json; charset=utf-8");
         response.setStatus(HttpServletResponse.SC_OK);

--- a/src/main/java/org/example/expert/security/handler/SecurityAuthenticationSuccessHandler.java
+++ b/src/main/java/org/example/expert/security/handler/SecurityAuthenticationSuccessHandler.java
@@ -9,12 +9,10 @@ import org.example.expert.config.JwtUtil;
 import org.example.expert.domain.auth.dto.response.SigninResponse;
 import org.example.expert.security.entity.CustomUserDetails;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
-import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
@@ -26,7 +24,7 @@ public class SecurityAuthenticationSuccessHandler extends SimpleUrlAuthenticatio
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
         CustomUserDetails userCustom = (CustomUserDetails) authentication.getPrincipal();
-        String bearerToken = jwtUtil.generateToken(userCustom.getId(), userCustom.getEmail(), userCustom.getUsername(), userCustom.getUserRole());
+        String bearerToken = jwtUtil.generateAccessToken(userCustom.getId(), userCustom.getEmail(), userCustom.getUsername(), userCustom.getUserRole());
         SigninResponse authLoginResponse = new SigninResponse(bearerToken);
 
         response.setContentType("application/json; charset=utf-8");

--- a/src/main/java/org/example/expert/security/handler/SecurityAuthenticationSuccessHandler.java
+++ b/src/main/java/org/example/expert/security/handler/SecurityAuthenticationSuccessHandler.java
@@ -7,6 +7,8 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.example.expert.config.JwtUtil;
 import org.example.expert.domain.auth.dto.response.SigninResponse;
+import org.example.expert.domain.auth.entity.RedisRefreshToken;
+import org.example.expert.domain.auth.repository.RedisRefreshTokenRepository;
 import org.example.expert.security.entity.CustomUserDetails;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
@@ -20,16 +22,20 @@ public class SecurityAuthenticationSuccessHandler extends SimpleUrlAuthenticatio
 
     private final JwtUtil jwtUtil;
     private final ObjectMapper objectMapper;
+    private final RedisRefreshTokenRepository refreshTokenRepository;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
         CustomUserDetails userCustom = (CustomUserDetails) authentication.getPrincipal();
+
         String accessToken = jwtUtil.generateAccessToken(userCustom.getId(), userCustom.getEmail(), userCustom.getUsername(), userCustom.getUserRole());
         String refreshToken = jwtUtil.generateRefreshToken(userCustom.getId());
-        SigninResponse authLoginResponse = new SigninResponse(accessToken, refreshToken);
+
+        RedisRefreshToken redisRefreshToken = new RedisRefreshToken(userCustom.getId(), refreshToken);
+        refreshTokenRepository.save(redisRefreshToken);
 
         response.setContentType("application/json; charset=utf-8");
         response.setStatus(HttpServletResponse.SC_OK);
-        response.getWriter().write(objectMapper.writeValueAsString(authLoginResponse));
+        response.getWriter().write(objectMapper.writeValueAsString(new SigninResponse(accessToken, refreshToken)));
     }
 }


### PR DESCRIPTION
- refresh token을 저장하기 위한 redis 추가 (반영구적인 저장 및 디스크 IO 감소)
- 회원가입, 로그인 로직에 refresh token 관련 로직 추가 및 응답 값 추가
- auth/reissue API 추가 : access token 및 refresh token 재발급(RTR)